### PR TITLE
Add Jest tests for member and admin classes

### DIFF
--- a/tests/admin.test.js
+++ b/tests/admin.test.js
@@ -1,0 +1,40 @@
+const { Member } = require('./models/member.js');
+const { Admin } = require('./models./admin.js');
+
+describe('Admin Class', () => {
+    it('should approve a member if "approved" is true', () => {
+        const newMember = new Member(
+            'Arzu',
+            'Caner',
+            'arzuguneycaner@gmail.com',
+            'Developer',
+            'London',
+            'Female',
+            'UK',
+            'pending'
+        );
+
+        const admin = new Admin();
+        admin.moderateRequests(newMember, true);
+
+        expect(newMember.status).toBe('approved');
+    });
+
+    it('should reject a member if "approved" is false', () => {
+        const newMember = new Member(
+            'Arzu',
+            'Caner',
+            'arzuguneycaner@gmail.com',
+            'Developer',
+            'London',
+            'Female',
+            'UK',
+            'pending'
+        );
+
+        const admin = new Admin();
+        admin.moderateRequests(newMember, false);
+
+        expect(newMember.status).toBe('rejected');
+    });
+});

--- a/tests/member.test.js
+++ b/tests/member.test.js
@@ -1,0 +1,25 @@
+const { Member } = require('./models/member.js');
+
+describe('Member Class', () => {
+    it('should create a member object with correct properties', () => {
+        const member = new Member(
+            'Arzu',
+            'Caner',
+            'arzuguneycaner@gmail.com',
+            'Developer',
+            'London',
+            'Female',
+            'UK',
+            'pending'
+        );
+
+        expect(member.firstName).toBe('Arzu');
+        expect(member.lastName).toBe('Caner');
+        expect(member.email).toBe('arzuguneycaner@gmail.com');
+        expect(member.job).toBe('Developer');
+        expect(member.city).toBe('London');
+        expect(member.gender).toBe('Female');
+        expect(member.country).toBe('UK');
+        expect(member.status).toBe('pending');
+    });
+});


### PR DESCRIPTION
This commit adds Jest test files for the Member and Admin classes, allowing us to thoroughly test their functionality.

In the `member.test.js` file, we've created tests to verify that the Member class creates objects with the correct properties.

In the `admin.test.js` file, we've created tests for the `moderateRequests` method of the Admin class. Different scenarios are tested, including approving and rejecting a member based on the "approved" parameter.

These tests help ensure that the Member and Admin classes are working as expected and that the logic for moderating requests is accurate. The tests also provide a safety net for future code changes.